### PR TITLE
Loader configs override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,9 @@ Each builder has a name and a `stack` property at minimum. Builder properties re
 |frontendRefreshOnBackendChange|Trigger web frontend refresh when backend code changes|
 |persistGraphQL|Generate and use Apollo persistent GraphQL queries|
 |devProxy|Proxy all unknown requests from front-end running on Webpack during development to back-end|
-|webpackConfig|Additional webpack config definitions merged in after config generation|
-|babelConfig|Additional babelrc definitions merged in after config generation|
 |writeStats|Write `stats.json` to disk, default: `false`|
 |nodeDebugger|To enable or disable node debugger, default: `true`|
+|{toolName}Config|Additional options for webpack, loaders or other tools. The `{toolName}` should be the name of the loader or tool and the value is the additional config options for the loader. Possible names for the tools are: `webpackConfig`, `babelConfig`, `cssConfig`, `sassConfig`, `graphqlTagConfig`, etc|
 
 Common builder options can be put into `options` property, from there they will be copied into each builder. `stack` property inside `options` will be prepended to each builder stack.
 Builder can also have builder-specific options, depending on its stack, recognized by `spinjs` plugins.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinjs",
-  "version": "0.4.115",
+  "version": "0.4.116",
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf ./lib",

--- a/src/Spin.ts
+++ b/src/Spin.ts
@@ -1,3 +1,4 @@
+// tslint:disable-next-line
 import { Configuration } from 'webpack';
 import * as merge from 'webpack-merge';
 
@@ -17,6 +18,11 @@ export default class Spin {
     this.dev = this.cmd === 'watch' || this.cmd === 'test';
     this.test = this.cmd === 'test';
     this.watch = this.cmd === 'watch';
+  }
+
+  public createConfig(builder: Builder, tool: string, config): Configuration {
+    const { merge: mergeStrategy, ...configOverrides } = builder[tool + 'Config'] || { merge: {} };
+    return this.mergeWithStrategy(mergeStrategy, config, configOverrides);
   }
 
   public merge(config: any, overrides: any): Configuration {

--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -96,10 +96,7 @@ const createConfig = (cwd: string, cmd: string, argv: any, builderName?: string)
     if (overrides[builder.name]) {
       builder.config = spin.mergeWithStrategy(strategy, builder.config, overrides[builder.name]);
     }
-    if (builder.webpackConfig) {
-      const { merge, ...config } = builder.webpackConfig;
-      builder.config = spin.mergeWithStrategy(merge || strategy, builder.config, config);
-    }
+    builder.config = spin.createConfig(builder, 'webpack', builder.config);
   }
 
   return { builders, spin };

--- a/src/plugins/AngularPlugin.ts
+++ b/src/plugins/AngularPlugin.ts
@@ -19,7 +19,7 @@ export default class AngularPlugin implements ConfigPlugin {
           rules: [
             {
               test: tsRule.test,
-              use: 'angular2-template-loader'
+              use: { loader: 'angular2-template-loader', options: spin.createConfig(builder, 'angular2Template', {}) }
             }
           ]
         },
@@ -51,7 +51,8 @@ export default class AngularPlugin implements ConfigPlugin {
             rules: [
               {
                 test: /\.html$/,
-                loader: 'html-loader'
+                loader: 'html-loader',
+                options: spin.createConfig(builder, 'html', {})
               }
             ]
           },

--- a/src/plugins/ApolloPlugin.ts
+++ b/src/plugins/ApolloPlugin.ts
@@ -41,12 +41,14 @@ export default class ApolloPlugin implements ConfigPlugin {
           rules: [
             {
               test: /\.graphqls/,
-              use: 'raw-loader'
+              use: { loader: 'raw-loader', options: spin.createConfig(builder, 'raw', {}) }
             },
             {
               test: /\.(graphql|gql)$/,
               exclude: /node_modules/,
-              use: ['graphql-tag/loader'].concat(persistGraphQL ? ['persistgraphql-webpack-plugin/graphql-loader'] : [])
+              use: [{ loader: 'graphql-tag/loader', options: spin.createConfig(builder, 'graphqlTag', {}) }].concat(
+                persistGraphQL ? ['persistgraphql-webpack-plugin/graphql-loader'] : ([] as any[])
+              )
             }
           ]
         }

--- a/src/plugins/BabelPlugin.ts
+++ b/src/plugins/BabelPlugin.ts
@@ -27,7 +27,6 @@ export default class BabelPlugin implements ConfigPlugin {
 
       const jsRuleFinder = new JSRuleFinder(builder);
       const jsRule = jsRuleFinder.findAndCreateJSRule();
-      const { merge, ...config } = builder.babelConfig || { merge: {} };
       const cacheDirectory =
         builder.cache === false || (builder.cache === 'auto' && !spin.dev)
           ? false
@@ -40,20 +39,16 @@ export default class BabelPlugin implements ConfigPlugin {
         loader: builder.require.probe('heroku-babel-loader') ? 'heroku-babel-loader' : 'babel-loader',
         options: !!babelrc
           ? { babelrc: true, cacheDirectory }
-          : spin.mergeWithStrategy(
-              merge,
-              {
-                babelrc: false,
-                cacheDirectory,
-                compact: !spin.dev,
-                presets: (['react', ['env', { modules: false }], 'stage-0'] as any[]).concat(
-                  spin.dev ? [] : [['minify', { mangle: false }]]
-                ),
-                plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
-                only: jsRuleFinder.extensions.map(ext => '*.' + ext)
-              },
-              config
-            )
+          : spin.createConfig(builder, 'babel', {
+              babelrc: false,
+              cacheDirectory,
+              compact: !spin.dev,
+              presets: (['react', ['env', { modules: false }], 'stage-0'] as any[]).concat(
+                spin.dev ? [] : [['minify', { mangle: false }]]
+              ),
+              plugins: ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties'],
+              only: jsRuleFinder.extensions.map(ext => '*.' + ext)
+            })
       };
     }
   }

--- a/src/plugins/CssProcessorPlugin.ts
+++ b/src/plugins/CssProcessorPlugin.ts
@@ -32,16 +32,18 @@ export default class CssProcessorPlugin implements ConfigPlugin {
             ? new RegExp(`^.*\\/node_modules\\/.*\\.${ext}$`)
             : new RegExp(`^(?!.*\\/node_modules\\/).*\\.${ext}$`),
           use: ([
-            { loader: 'isomorphic-style-loader' },
-            { loader: 'css-loader', options: { ...loaderOptions } }
+            { loader: 'isomorphic-style-loader', options: spin.createConfig(builder, 'isomorphicStyle', {}) },
+            { loader: 'css-loader', options: spin.createConfig(builder, 'css', { ...loaderOptions }) }
           ] as any[])
             .concat(
               postCssLoader && !nodeModules
                 ? {
                     loader: postCssLoader,
-                    options: useDefaultPostCss
-                      ? { ...postCssDefaultConfig(builder), ...loaderOptions }
-                      : { ...loaderOptions }
+                    options: spin.createConfig(
+                      builder,
+                      'postCss',
+                      useDefaultPostCss ? { ...postCssDefaultConfig(builder), ...loaderOptions } : { ...loaderOptions }
+                    )
                   }
                 : []
             )
@@ -62,16 +64,23 @@ export default class CssProcessorPlugin implements ConfigPlugin {
               : new RegExp(`^(?!.*\\/node_modules\\/).*\\.${ext}$`),
             use: dev
               ? ([
-                  { loader: 'style-loader' },
-                  { loader: 'css-loader', options: { ...loaderOptions, importLoaders: 1 } }
+                  { loader: 'style-loader', options: spin.createConfig(builder, 'style', {}) },
+                  {
+                    loader: 'css-loader',
+                    options: spin.createConfig(builder, 'css', { ...loaderOptions, importLoaders: 1 })
+                  }
                 ] as any[])
                   .concat(
                     postCssLoader && !nodeModules
                       ? {
                           loader: postCssLoader,
-                          options: useDefaultPostCss
-                            ? { ...postCssDefaultConfig(builder), ...loaderOptions }
-                            : { ...loaderOptions }
+                          options: spin.createConfig(
+                            builder,
+                            'postCss',
+                            useDefaultPostCss
+                              ? { ...postCssDefaultConfig(builder), ...loaderOptions }
+                              : { ...loaderOptions }
+                          )
                         }
                       : []
                   )
@@ -81,15 +90,21 @@ export default class CssProcessorPlugin implements ConfigPlugin {
                   use: [
                     {
                       loader: 'css-loader',
-                      options: { importLoaders: postCssLoader && !nodeModules ? 1 : 0 }
+                      options: spin.createConfig(builder, 'css', {
+                        importLoaders: postCssLoader && !nodeModules ? 1 : 0
+                      })
                     }
                   ]
                     .concat(
                       postCssLoader && !nodeModules
-                        ? {
+                        ? ({
                             loader: postCssLoader,
-                            options: useDefaultPostCss ? postCssDefaultConfig(builder) : {}
-                          } as any
+                            options: spin.createConfig(
+                              builder,
+                              'postCss',
+                              useDefaultPostCss ? postCssDefaultConfig(builder) : {}
+                            )
+                          } as any)
                         : []
                     )
                     .concat(ruleList ? ruleList.map(rule => rule.loader) : [])
@@ -103,12 +118,12 @@ export default class CssProcessorPlugin implements ConfigPlugin {
       }
 
       if (createRule && stack.hasAny('sass')) {
-        const sassRule = [{ loader: 'sass-loader', options: { ...loaderOptions } }];
+        const sassRule = [{ loader: 'sass-loader', options: spin.createConfig(builder, 'sass', { ...loaderOptions }) }];
         rules.push(createRule('scss', false, sassRule), createRule('scss', true, sassRule));
       }
 
       if (createRule && stack.hasAny('less')) {
-        const lessRule = [{ loader: 'less-loader', options: { ...loaderOptions } }];
+        const lessRule = [{ loader: 'less-loader', options: spin.createConfig(builder, 'less', { ...loaderOptions }) }];
         rules.push(createRule('less', false, lessRule), createRule('less', true, lessRule));
       }
 

--- a/src/plugins/I18NextPlugin.ts
+++ b/src/plugins/I18NextPlugin.ts
@@ -14,7 +14,7 @@ export default class I18NextPlugin implements ConfigPlugin {
           rules: [
             {
               test: /locales/,
-              use: '@alienfast/i18next-loader'
+              use: { loader: '@alienfast/i18next-loader', options: spin.createConfig(builder, 'i18next', {}) }
             }
           ]
         }

--- a/src/plugins/ReactNativePlugin.ts
+++ b/src/plugins/ReactNativePlugin.ts
@@ -36,8 +36,6 @@ export default class ReactNativePlugin implements ConfigPlugin {
       const AssetResolver = builder.require('haul/src/resolvers/AssetResolver');
       const HasteResolver = builder.require('haul/src/resolvers/HasteResolver');
 
-      const { merge, ...config } = builder.babelConfig || { merge: {} };
-
       const babelrc = new UPFinder(builder).find(['.babelrc.native']);
 
       const jsRuleFinder = new JSRuleFinder(builder);
@@ -67,15 +65,11 @@ export default class ReactNativePlugin implements ConfigPlugin {
         exclude: /node_modules\/(?!react-native.*|@expo|expo|lottie-react-native|haul|pretty-format|react-navigation)$/,
         use: {
           loader: builder.require.probe('heroku-babel-loader') ? 'heroku-babel-loader' : 'babel-loader',
-          options: spin.mergeWithStrategy(
-            merge,
-            {
-              babelrc: false,
-              cacheDirectory,
-              ...defaultConfig
-            },
-            config
-          )
+          options: spin.createConfig(builder, 'babel', {
+            babelrc: false,
+            cacheDirectory,
+            ...defaultConfig
+          })
         }
       });
 
@@ -97,12 +91,12 @@ export default class ReactNativePlugin implements ConfigPlugin {
               test: mobileAssetTest,
               use: {
                 loader: 'spinjs/lib/plugins/react-native/assetLoader',
-                query: {
+                options: spin.createConfig(builder, 'asset', {
                   platform: stack.platform,
                   root: builder.require.cwd,
                   cwd: spin.cwd,
                   bundle: false
-                }
+                })
               }
             }
           ]

--- a/src/plugins/TypeScriptPlugin.ts
+++ b/src/plugins/TypeScriptPlugin.ts
@@ -17,7 +17,7 @@ export default class TypeScriptPlugin implements ConfigPlugin {
       tsRule.use = [
         {
           loader: 'awesome-typescript-loader',
-          options: { ...builder.tsLoaderOptions }
+          options: spin.createConfig(builder, 'awesomeTypescript', { ...builder.tsLoaderOptions })
         }
       ];
 

--- a/src/plugins/VuePlugin.ts
+++ b/src/plugins/VuePlugin.ts
@@ -14,7 +14,7 @@ export default class VuePlugin implements ConfigPlugin {
           rules: [
             {
               test: /\.vue$/,
-              use: 'vue-loader'
+              use: { loader: 'vue-loader', options: spin.createConfig(builder, 'vue', {}) }
             }
           ]
         },

--- a/src/plugins/WebAssetsPlugin.ts
+++ b/src/plugins/WebAssetsPlugin.ts
@@ -17,29 +17,29 @@ export default class WebAssetsPlugin implements ConfigPlugin {
               test: /\.(png|ico|jpg|gif|xml)$/,
               use: {
                 loader: 'url-loader',
-                options: {
+                options: spin.createConfig(builder, 'url', {
                   name: '[hash].[ext]',
                   limit: 100000
-                }
+                })
               }
             },
             {
               test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
               use: {
                 loader: 'url-loader',
-                options: {
+                options: spin.createConfig(builder, 'url', {
                   name: '[hash].[ext]',
                   limit: 100000
-                }
+                })
               }
             },
             {
               test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
               use: {
                 loader: 'file-loader',
-                options: {
+                options: spin.createConfig(builder, 'file', {
                   name: '[hash].[ext]'
-                }
+                })
               }
             }
           ]


### PR DESCRIPTION
Implement support for `builder.{toolName}Config` - additional options for webpack, loaders or other tools. The `{toolName}` should be the name of the loader or tool and the value is the additional config options for the loader. Possible names for the tools are: `webpackConfig`, `babelConfig`, `cssConfig`, `sassConfig`, `graphqlTagConfig`, etc
