### PR TITLE
Honor Yarn Workspaces paths during builder config discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "containerized": "^1.0.2",
     "debug": "^3.1.0",
     "detect-port": "^1.2.2",
+    "glob": "^7.1.2",
     "humps": "^2.0.1",
     "inquirer": "^3.3.0",
     "ip": "^1.1.5",

--- a/src/BuilderDiscoverer.ts
+++ b/src/BuilderDiscoverer.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs';
+import { glob } from 'glob';
+import * as _ from 'lodash';
 import * as path from 'path';
 
 import { Builder, Builders } from './Builder';
@@ -19,7 +21,10 @@ export default class BuilderDiscoverer {
   }
 
   public discover(): Builders {
-    return this._discoverRecursively(this.cwd);
+    const packagesPaths = this._detectPaths();
+    return packagesPaths.reduce((res: any, pathName: string) => {
+      return { ...res, ...this._discoverRecursively(pathName) };
+    }, {});
   }
 
   private _discoverRecursively(dir: string): Builders {
@@ -45,5 +50,12 @@ export default class BuilderDiscoverer {
     }
 
     return builders;
+  }
+
+  private _detectPaths(): string[] {
+    const rootConfig = JSON.parse(fs.readFileSync(`${this.cwd}/package.json`, 'utf8'));
+    return rootConfig.workspaces && rootConfig.workspaces.length
+      ? _.flatten(rootConfig.workspaces.map((ws: string) => glob.sync(ws))).map((ws: string) => path.join(this.cwd, ws))
+      : [this.cwd];
   }
 }

--- a/src/BuilderDiscoverer.ts
+++ b/src/BuilderDiscoverer.ts
@@ -21,8 +21,8 @@ export default class BuilderDiscoverer {
   }
 
   public discover(): Builders {
-    const packagesPaths = this._detectPaths();
-    return packagesPaths.reduce((res: any, pathName: string) => {
+    const packageRootPaths = this._detectRootPaths();
+    return packageRootPaths.reduce((res: any, pathName: string) => {
       return { ...res, ...this._discoverRecursively(pathName) };
     }, {});
   }
@@ -52,7 +52,7 @@ export default class BuilderDiscoverer {
     return builders;
   }
 
-  private _detectPaths(): string[] {
+  private _detectRootPaths(): string[] {
     const rootConfig = JSON.parse(fs.readFileSync(`${this.cwd}/package.json`, 'utf8'));
     return rootConfig.workspaces && rootConfig.workspaces.length
       ? _.flatten(rootConfig.workspaces.map((ws: string) => glob.sync(ws))).map((ws: string) => path.join(this.cwd, ws))

--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -53,7 +53,7 @@ const createConfig = (cwd: string, cmd: string, argv: any, builderName?: string)
   const builderDiscoverer = new BuilderDiscoverer(spin, plugins, argv);
   const role = cmd === 'exp' ? 'build' : cmd;
 
-  const discoveredBuilders = builderDiscoverer.discover() || {};
+  const discoveredBuilders = builderDiscoverer.discover();
   if (!discoveredBuilders) {
     throw new Error('Cannot find spinjs config');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,7 +1032,7 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
-glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:


### PR DESCRIPTION
Limit recursive builder configs discovery by taking into account Yarn Workspaces paths.