### PR TITLE
Remove LoaderOptionsPlugin from WebpackPlugin.ts

### DIFF
--- a/src/plugins/WebpackPlugin.ts
+++ b/src/plugins/WebpackPlugin.ts
@@ -40,7 +40,6 @@ const createPlugins = (builder: Builder, spin: Spin) => {
       }
     }
   } else {
-    const loaderOpts: any = { minimize: builder.minify };
     if (builder.minify) {
       const uglifyOpts: any = { test: /\.(js|bundle)(\?.*)?$/i, cache: true, parallel: true };
       if (builder.sourceMap) {
@@ -52,13 +51,7 @@ const createPlugins = (builder: Builder, spin: Spin) => {
       }
       const UglifyJsPlugin = builder.require('uglifyjs-webpack-plugin');
       plugins.push(new UglifyJsPlugin(uglifyOpts));
-      if (stack.hasAny('angular')) {
-        loaderOpts.htmlLoader = {
-          minimize: false // workaround for ng2
-        };
-      }
     }
-    plugins.push(new webpack.LoaderOptionsPlugin(loaderOpts));
     if (webpackVer < 4) {
       plugins.push(new webpack.optimize.ModuleConcatenationPlugin());
     }


### PR DESCRIPTION
[#5](https://github.com/sysgears/spinjs/issues/5)

> In spinjs/src/plugins/WebpackPlugin.ts:61, remove LoaderOptionsPlugin from the plugins array as it seems like a legacy plugin from webpack v1/v2.


