### PR TITLE
Adding support for expo-cli

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ try {
     .command('build', 'compiles package for usage in production')
     .command(['watch', 'start'], 'launches package in development mode with hot code reload')
     .command('exp', 'launches server for exp and exp tool')
+    .command('expo', 'launches server for expo and expo tool')
     .command('test [mocha-webpack options]', 'runs package tests')
     .demandCommand(1, '')
     .option('c', {
@@ -26,13 +27,14 @@ try {
     .version(require('../package.json').version) // tslint:disable-line
     .argv;
 
-  const cmd = argv._[0];
+  const cmd: string = argv._[0];
   let config;
-  if (argv.help && cmd !== 'exp') {
+
+  if (argv.help && !(cmd === 'exp' || cmd === 'expo')) {
     yargs.showHelp();
   } else {
     const cwd = process.cwd();
-    if (['exp', 'build', 'test', 'watch', 'start'].indexOf(cmd) >= 0) {
+    if (['exp', 'expo', 'build', 'test', 'watch', 'start'].indexOf(cmd) >= 0) {
       config = createConfig(cwd, cmd, argv);
     }
 

--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -52,7 +52,7 @@ const createConfig = (cwd: string, cmd: string, argv: any, builderName?: string)
   const spin = new Spin(cwd, cmd);
   const builderDiscoverer = new BuilderDiscoverer(spin, plugins, argv);
   let role = cmd;
-  if (cmd === 'exp') {
+  if (cmd === 'exp' || cmd === 'expo') {
     role = 'build';
   } else if (cmd === 'start') {
     role = 'watch';

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -981,6 +981,12 @@ const startExpoProdServer = async (spin: Spin, mainBuilder: Builder, builders: B
   logger.info(`Expo server running on address: ${localAddress}`);
 };
 
+/**
+ * startExp contains the logic for the legacy 'exp' module.
+ * @param spin
+ * @param builders
+ * @param logger
+ */
 const startExp = async (spin: Spin, builders: Builders, logger) => {
   let mainBuilder: Builder;
   for (const name of Object.keys(builders)) {
@@ -1010,6 +1016,47 @@ const startExp = async (spin: Spin, builders: Builders, logger) => {
       }
     );
     exp.on('exit', code => {
+      process.exit(code);
+    });
+  }
+};
+
+/**
+ * startExpo contains the logic for the 'expo-cli' module.
+ *
+ * @param spin
+ * @param builders
+ * @param logger
+ */
+const startExpo = async (spin: Spin, builders: Builders, logger) => {
+  let mainBuilder: Builder;
+  for (const name of Object.keys(builders)) {
+    const builder = builders[name];
+    if (builder.stack.hasAny(['ios', 'android'])) {
+      mainBuilder = builder;
+      break;
+    }
+  }
+  if (!mainBuilder) {
+    throw new Error('Builders for `ios` or `android` not found');
+  }
+
+  const projectRoot = path.join(process.cwd(), '.expo', 'all');
+  setupExpoDir(spin, mainBuilder, projectRoot, 'all');
+  const expIdx = process.argv.indexOf('expo');
+  if (['ba', 'bi', 'build:android', 'build:ios', 'publish', 'p', 'server'].indexOf(process.argv[expIdx + 1]) >= 0) {
+    await startExpoProdServer(spin, mainBuilder, builders, logger);
+  }
+  if (process.argv[expIdx + 1] !== 'server') {
+    const expo = spawn(
+      path.join(process.cwd(), 'node_modules/.bin/expo' + (__WINDOWS__ ? '.cmd' : '')),
+      process.argv.splice(expIdx + 1),
+      {
+        cwd: projectRoot,
+        stdio: [0, 1, 2]
+      }
+    );
+    expo.on('exit', code => {
       process.exit(code);
     });
   }
@@ -1047,6 +1094,8 @@ const execute = (cmd: string, argv: any, builders: Builders, spin: Spin) => {
 
     if (cmd === 'exp') {
       startExp(spin, builders, spinLogger);
+    } else if (cmd === 'expo') {
+      startExpo(spin, builders, spinLogger);
     } else if (cmd === 'test') {
       // TODO: Remove this in 0.5.x
       let builder;


### PR DESCRIPTION
- all Expo commands now use `expo` instead of `exp`.
- this is an API breaking change!
- GitHub issue #11