### PR TITLE
Update the webpack configuration in Angular Plugin

### DIFF
--- a/src/plugins/AngularPlugin.ts
+++ b/src/plugins/AngularPlugin.ts
@@ -20,14 +20,35 @@ export default class AngularPlugin implements ConfigPlugin {
             {
               test: tsRule.test,
               use: { loader: 'angular2-template-loader', options: spin.createConfig(builder, 'angular2Template', {}) }
+            },
+            /**
+             * Enabling the SystemJS parser for the .js files under @angular/core/ will disable
+             * the deprecation warnings.
+             * See https://prntscr.com/lezfmd
+             *
+             * SystemJS is disabled by default for webpack.
+             * See https://webpack.js.org/configuration/module/#rule-parser
+             *
+             * Note that the webpack.ContextReplacementPlugin must also be properly configured (see below).
+             */
+            {
+              test: /[\\\/]@angular[\\\/]core[\\\/].+\.js$/,
+              parser: { system: true }
             }
           ]
         },
         plugins: [
           // Workaround for angular/angular#11580
           new webpack.ContextReplacementPlugin(
-            // The (\\|\/) piece accounts for path separators in *nix and Windows
-            /angular[\\\/]core[\\\/]@angular/,
+            /**
+             * Override the initial configuration for ContextReplacementPlugin.
+             * The argument /angular[\\\/]core[\\\/]@angular/ causes several warnings.
+             * See https://prnt.sc/lezevh
+             *
+             * It's necessary to remove the @angular part and fix the issue by enabling
+             * the proper module.rules.Rule for @angular/core/*.js files(see above).
+             */
+            /angular[\\\/]core/,
             path.join(builder.require.cwd, 'src'),
             {} // a map of your routes
           )

--- a/src/plugins/AngularPlugin.ts
+++ b/src/plugins/AngularPlugin.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import { Builder } from '../Builder';
 import { ConfigPlugin } from '../ConfigPlugin';
 import Spin from '../Spin';
@@ -48,9 +46,7 @@ export default class AngularPlugin implements ConfigPlugin {
              * It's necessary to remove the @angular part and fix the issue by enabling
              * the proper module.rules.Rule for @angular/core/*.js files(see above).
              */
-            /angular[\\\/]core/,
-            path.join(builder.require.cwd, 'src'),
-            {} // a map of your routes
+            /angular[\\\/]core/
           )
         ]
       });


### PR DESCRIPTION
The workaround with webpack.ContextReplacementPlugin for angular/angular#11580 doesn’t really work for Angular 4, 5, 6, and 7:

Warning #1: [https://prnt.sc/lezevh](https://prnt.sc/lezevh)
Warning #2: [https://prnt.sc/lezfmd](https://prnt.sc/lezfmd)

The update brings the changes in `AngularPlugin.ts` to suppress the warnings.