### PR TITLE
Add base tag for compatibility with Angular applications

### DIFF
--- a/html-plugin-template.ejs
+++ b/html-plugin-template.ejs
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <base href="/" />
     <meta charset="utf-8">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/html-plugin-template.ejs
+++ b/html-plugin-template.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <base href="/" />
+    <base href="/">
     <meta charset="utf-8">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Add ```<base href="/" />``` to HTML template.
Needed for Angular applications to tell the router how to compose navigation URLs