### PR TITLE
Add support for app modules in @module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinjs",
-  "version": "0.4.173-alpha.0",
+  "version": "0.4.173-alpha.1",
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf ./lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinjs",
-  "version": "0.4.172",
+  "version": "0.4.173-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf ./lib",

--- a/src/plugins/ApolloPlugin.ts
+++ b/src/plugins/ApolloPlugin.ts
@@ -47,7 +47,6 @@ export default class ApolloPlugin implements ConfigPlugin {
             },
             {
               test: /\.(graphql|gql)$/,
-              exclude: /node_modules/,
               use: [{ loader: 'graphql-tag/loader', options: spin.createConfig(builder, 'graphqlTag', {}) }].concat(
                 persistGraphQL ? ['persistgraphql-webpack-plugin/graphql-loader'] : ([] as any[])
               )

--- a/src/plugins/ReactNativePlugin.ts
+++ b/src/plugins/ReactNativePlugin.ts
@@ -75,7 +75,7 @@ export default class ReactNativePlugin implements ConfigPlugin {
               .pop()
               .slice(0, -1)
         ),
-        exclude: /node_modules\/(?!react-native.*|@expo|expo|lottie-react-native|haul|pretty-format|react-navigation|antd-mobile-rn)$/,
+        exclude: /node_modules[\\\/](?!react-native.*|@module|@expo|expo|lottie-react-native|haul|pretty-format|react-navigation|antd-mobile-rn)$/,
         use: {
           loader: builder.require.probe('heroku-babel-loader') ? 'heroku-babel-loader' : 'babel-loader',
           options: spin.createConfig(

--- a/src/plugins/ReactPlugin.ts
+++ b/src/plugins/ReactPlugin.ts
@@ -15,13 +15,13 @@ export default class ReactPlugin implements ConfigPlugin {
       const jsRule = jsRuleFinder.findJSRule();
       const tsRule = jsRuleFinder.findTSRule();
       if (jsRule) {
-        jsRule.test = /^(?!.*[\\\/]node_modules[\\\/]).*\.jsx?$/;
+        jsRule.test = /\.jsx?$/;
         if (jsRule.use && jsRule.use.loader && jsRule.use.loader.indexOf('babel') >= 0 && !jsRule.use.options.babelrc) {
           jsRule.use.options.only = jsRuleFinder.extensions.map(ext => '*.' + ext);
         }
       }
       if (tsRule) {
-        tsRule.test = /^(?!.*[\\\/]node_modules[\\\/]).*\.tsx?$/;
+        tsRule.test = /\.tsx?$/;
       }
 
       const majorVer = builder.require('react/package.json').version.split('.')[0];

--- a/src/plugins/TypeScriptPlugin.ts
+++ b/src/plugins/TypeScriptPlugin.ts
@@ -30,7 +30,7 @@ export default class TypeScriptPlugin implements ConfigPlugin {
 
       const jsRuleFinder = new JSRuleFinder(builder);
       const tsRule = jsRuleFinder.findAndCreateTSRule();
-      tsRule.test = /^(?!.*[\\\/]node_modules[\\\/]).*\.ts$/;
+      tsRule.test = /\.ts$/;
       tsRule.use = addParalleLoaders(builder, spin, [
         atl
           ? {

--- a/src/plugins/shared/JSRuleFinder.ts
+++ b/src/plugins/shared/JSRuleFinder.ts
@@ -31,7 +31,7 @@ export default class JSRuleFinder {
     if (this.jsRule) {
       throw new Error('js rule already exists!');
     }
-    this.jsRule = { test: /\.js$/ };
+    this.jsRule = { test: /\.js$/, exclude: /node_modules[\\\/](?!@module)/ };
     this.builder.config.module.rules = this.builder.config.module.rules.concat(this.jsRule);
     return this.jsRule;
   }
@@ -61,7 +61,7 @@ export default class JSRuleFinder {
     if (this.tsRule) {
       throw new Error('ts rule already exists!');
     }
-    this.tsRule = { test: /\.ts$/ };
+    this.tsRule = { test: /\.ts$/, exclude: /node_modules[\\\/](?!@module)/ };
     this.builder.config.module.rules = this.builder.config.module.rules.concat(this.tsRule);
     return this.tsRule;
   }

--- a/src/plugins/shared/JSRuleFinder.ts
+++ b/src/plugins/shared/JSRuleFinder.ts
@@ -31,7 +31,7 @@ export default class JSRuleFinder {
     if (this.jsRule) {
       throw new Error('js rule already exists!');
     }
-    this.jsRule = { test: /^(?!.*[\\\/]node_modules[\\\/]).*\.js$/ };
+    this.jsRule = { test: /\.js$/ };
     this.builder.config.module.rules = this.builder.config.module.rules.concat(this.jsRule);
     return this.jsRule;
   }
@@ -61,7 +61,7 @@ export default class JSRuleFinder {
     if (this.tsRule) {
       throw new Error('ts rule already exists!');
     }
-    this.tsRule = { test: /^(?!.*[\\\/]node_modules[\\\/]).*\.ts$/ };
+    this.tsRule = { test: /\.ts$/ };
     this.builder.config.module.rules = this.builder.config.module.rules.concat(this.tsRule);
     return this.tsRule;
   }


### PR DESCRIPTION
Add support for app-level modules in @module namespace. `spinjs` will compile source code inside these modules, instead just importing them as is.