### PR TITLE
Update options for uglifyjs in Webpack plugin

### DIFF
--- a/src/plugins/WebpackPlugin.ts
+++ b/src/plugins/WebpackPlugin.ts
@@ -47,8 +47,10 @@ const createPlugins = (builder: Builder, spin: Spin) => {
       }
       if (stack.hasAny('angular')) {
         // https://github.com/angular/angular/issues/10618
-        uglifyOpts.mangle = {
-          keep_fname7e8a6ea17be4d30d84376e45f0c76e63b3d23893s7e8a6ea17be4d30d84376e45f0c76e63b3d23893: true
+        uglifyOpts.uglifyOptions = {
+          mangle: {
+            keep_fnames: true
+          }
         };
       }
       const UglifyJsPlugin = builder.require('uglifyjs-webpack-plugin');


### PR DESCRIPTION
After [#63](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/pull/63) `mangle` option must be nested in `uglifyOptions` 