### PR TITLE
Add VueLoaderPlugin

### DIFF
--- a/src/plugins/VuePlugin.ts
+++ b/src/plugins/VuePlugin.ts
@@ -8,6 +8,7 @@ export default class VuePlugin implements ConfigPlugin {
 
     if (stack.hasAll(['vue', 'webpack'])) {
       const webpack = builder.require('webpack');
+      const VueLoaderPlugin = builder.require('vue-loader/lib/plugin');
 
       builder.config = spin.merge(builder.config, {
         module: {
@@ -22,7 +23,8 @@ export default class VuePlugin implements ConfigPlugin {
           alias: {
             vue$: 'vue/dist/vue.esm.js'
           }
-        }
+        },
+        plugins: [new VueLoaderPlugin()]
       });
     }
   }


### PR DESCRIPTION
This PR adds a Vue-Loader plugin according to Vue Loader [docs](https://vue-loader.vuejs.org/guide/#manual-configuration).

> It is responsible for cloning any other rules you have defined and applying them to the corresponding language blocks in .vue files.